### PR TITLE
Asynq utils

### DIFF
--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -1,0 +1,80 @@
+# Python Imports
+import logging
+import asyncio
+from typing import Iterable, List, Tuple, Dict, Optional
+
+# Project Imports
+from src.status_backend import StatusBackend
+
+
+logger = logging.getLogger(__name__)
+
+
+def make_jobs(senders: Iterable[str], receivers: Iterable[str]) -> List[Tuple[str, str]]:
+    """Cartesian product of senders x receivers."""
+    return [(s, r) for s in senders for r in receivers]
+
+
+async def enqueue_jobs(job_q: asyncio.Queue[Optional[Tuple[str, str]]],
+                       jobs: List[Tuple[str, str]]) -> None:
+    for job in jobs:
+        logger.info(f"Enqueued job: {job}")
+        await job_q.put(job)
+    logger.info("Adding none, no more jobs")
+    await job_q.put(None)
+
+
+async def launch_workers(nodes: Dict[str, StatusBackend],
+                         job_q: asyncio.Queue[Optional[Tuple[str, str]]],
+                         done_q: asyncio.Queue[Optional[asyncio.Task]],
+                         intermediate_delay: float,
+                         max_in_flight: int = 0,
+                         func = None) -> None:
+
+    sem = asyncio.Semaphore(max_in_flight) if max_in_flight > 0 else None
+
+    while True:
+        item = await job_q.get()
+        if item is None:
+            logger.info("No more jobs, exiting launcher")
+            break
+
+        sender, receiver = item
+
+        if sem is not None:
+            await sem.acquire()
+
+        logger.info(f"Launching job {func.__name__}: {sender} -> {receiver}")
+        fut = asyncio.create_task(func(nodes, sender, receiver))
+        # TODO correctly attach metadata for logging/errors
+        fut._sender_receiver = (sender, receiver)  # type: ignore[attr-defined]
+
+        def _on_done(t: asyncio.Task) -> None:
+            # release concurrency slot (if any), then notify collector
+            if sem is not None:
+                sem.release()
+            done_q.put_nowait(t)
+
+        fut.add_done_callback(_on_done)
+
+        await asyncio.sleep(intermediate_delay)
+
+    logger.info("Adding None, no more workers")
+    await done_q.put(None)
+
+
+async def collect_results(done_q: asyncio.Queue[asyncio.Task | None], function: str = None) -> List:
+    results: List = []
+    while True:
+        fut = await done_q.get()
+        if fut is None:
+            logger.info(f"No more results to collect from {function}")
+            break
+        try:
+            result = await fut
+            logger.info(f"Collected result from {function}")
+            results.append(result)
+        except Exception as e:
+            logger.error(f"Error collecting result from {function}: {e!r}")
+
+    return results

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -1,6 +1,7 @@
 # Python Imports
-import logging
 import asyncio
+import logging
+import traceback
 from typing import Iterable, List, Tuple, Dict, Optional
 
 # Project Imports
@@ -76,6 +77,7 @@ async def collect_results(done_q: asyncio.Queue[asyncio.Task | None], function: 
             logger.info(f"Collected result from {function}")
             results.append(result)
         except Exception as e:
-            logger.error(f"Error collecting result from {function}: {e!r}")
+            logger.error(f"Error collecting result from {function}: {e!r}\n"
+                         f"{traceback.format_exc()}")
 
     return results

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -31,7 +31,7 @@ async def launch_workers(worker_tasks: List[partial], done_queue: asyncio.Queue[
                 sem.release()
             try:
                 result = t.result()
-                done_queue.put_nowait(("ok", (j.func.__name__, j.args[1:], result)))
+                done_queue.put_nowait(("ok", (j, result)))
             except Exception as e:
                 tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
                 done_queue.put_nowait(("err", (e, tb)))
@@ -47,8 +47,8 @@ async def collect_results(done_q: asyncio.Queue[tuple[str, object]], total_tasks
     for _ in range(total_tasks):
         status, payload = await done_q.get()
         if status == "ok":
-            func_name, args, results = payload
-            logger.info(f"Task completed: {func_name} {args}")
+            partial_object, results = payload
+            logger.info(f"Task completed: {partial_object.func.__name__} {partial_object.args[1:]}")
             collected.append(results)
         else:
             e, tb = payload  # from the launcher callback

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -64,6 +64,7 @@ async def launch_workers(nodes: Dict[str, StatusBackend],
 
 
 async def collect_results(done_q: asyncio.Queue[asyncio.Task | None], function: str = None) -> List:
+    """Collect results from `done_q` until `done_q` yields `None`."""
     results: List = []
     while True:
         fut = await done_q.get()

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -2,82 +2,56 @@
 import asyncio
 import logging
 import traceback
-from typing import Iterable, List, Tuple, Dict, Optional
+from functools import partial
+from typing import List, Tuple
 
 # Project Imports
-from src.status_backend import StatusBackend
 
 
 logger = logging.getLogger(__name__)
+# [(node_sender, {node_receiver: (timestamp, message)}), ...]
+RequestResult = Tuple[str, dict[str, Tuple[int, str]]]
 
 
-def make_jobs(senders: Iterable[str], receivers: Iterable[str]) -> List[Tuple[str, str]]:
-    """Cartesian product of senders x receivers."""
-    return [(s, r) for s in senders for r in receivers]
-
-
-async def enqueue_jobs(job_q: asyncio.Queue[Optional[Tuple[str, str]]],
-                       jobs: List[Tuple[str, str]]) -> None:
-    for job in jobs:
-        logger.info(f"Enqueued job: {job}")
-        await job_q.put(job)
-    logger.info("Adding none, no more jobs")
-    await job_q.put(None)
-
-
-async def launch_workers(nodes: Dict[str, StatusBackend],
-                         job_q: asyncio.Queue[Optional[Tuple[str, str]]],
-                         done_q: asyncio.Queue[Optional[asyncio.Task]],
-                         intermediate_delay: float,
-                         max_in_flight: int = 0,
-                         func = None) -> None:
+async def launch_workers(worker_tasks: List[partial], done_queue: asyncio.Queue[tuple[str, object]], intermediate_delay: float,
+                         max_in_flight: int = 0) -> None:
 
     sem = asyncio.Semaphore(max_in_flight) if max_in_flight > 0 else None
 
-    while True:
-        item = await job_q.get()
-        if item is None:
-            logger.info("No more jobs, exiting launcher")
-            break
-
-        sender, receiver = item
-
+    for worker in worker_tasks:
         if sem is not None:
             await sem.acquire()
 
-        logger.info(f"Launching job {func.__name__}: {sender} -> {receiver}")
-        fut = asyncio.create_task(func(nodes, sender, receiver))
-        # TODO correctly attach metadata for logging/errors
-        fut._sender_receiver = (sender, receiver)  # type: ignore[attr-defined]
+        # worker.args has (nodes, sender, receiver)
+        logger.info(f"Launching task {worker.func.__name__}: {worker.args[1:]}")
+        fut = asyncio.create_task(worker())
 
-        def _on_done(t: asyncio.Task) -> None:
-            # release concurrency slot (if any), then notify collector
+        def _on_done(t: asyncio.Task, j=worker) -> None:
             if sem is not None:
                 sem.release()
-            done_q.put_nowait(t)
+            try:
+                result = t.result()
+                done_queue.put_nowait(("ok", (j.func.__name__, j.args[1:], result)))
+            except Exception as e:
+                tb = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+                done_queue.put_nowait(("err", (e, tb)))
 
         fut.add_done_callback(_on_done)
 
-        await asyncio.sleep(intermediate_delay)
-
-    logger.info("Adding None, no more workers")
-    await done_q.put(None)
+        if intermediate_delay:
+            await asyncio.sleep(intermediate_delay)
 
 
-async def collect_results(done_q: asyncio.Queue[asyncio.Task | None], function: str = None) -> List:
-    """Collect results from `done_q` until `done_q` yields `None`."""
-    results: List = []
-    while True:
-        fut = await done_q.get()
-        if fut is None:
-            logger.info(f"No more results to collect from {function}")
-            break
-        try:
-            result = await fut
-            logger.info(f"Collected result from {function}")
-            results.append(result)
-        except Exception as e:
-            logger.error(f"Error collecting result from {function}: {e!r}\n"
-                         f"{traceback.format_exc()}")
+async def collect_results(done_q: asyncio.Queue[tuple[str, object]], total_tasks: int) -> List[RequestResult]:
+    collected: List[RequestResult] = []
+    for _ in range(total_tasks):
+        status, payload = await done_q.get()
+        if status == "ok":
+            func_name, args, results = payload
+            logger.info(f"Task completed: {func_name} {args}")
+            collected.append(results)
+        else:
+            e, tb = payload  # from the launcher callback
+            logger.error(f"Task failed: {e}\n{tb}", e, tb)
 
-    return results
+    return collected

--- a/src/benchmark_scenarios/private_chats.py
+++ b/src/benchmark_scenarios/private_chats.py
@@ -23,8 +23,16 @@ async def idle_relay():
 
     alice = "status-backend-relay-0"
     friends = [key for key in relay_nodes.keys() if key != alice]
-    requests_made = await send_friend_requests(relay_nodes, [alice], friends)
-    _ = await accept_friend_requests(relay_nodes, requests_made)
+
+    requests_made = await send_friend_requests(relay_nodes, [alice], friends, 1)
+    logger.info("Accepting friend requests")
+    delays = await accept_friend_requests(relay_nodes, requests_made)
+    # TODO: These delays include the accumulation of intermediate_delays, they are not accurate.
+    # Intermediate delay is needed to not saturate status node, otherwise request don't arrive.
+    # TODO: We should merge send and receive operations in asynq queues as well
+    logger.info(f"Delays are: {delays}")
+    logger.info("Waiting 30 seconds")
+    await asyncio.sleep(30)
 
     logger.info("Shutting down node connections")
     await asyncio.gather(*[node.shutdown() for node in relay_nodes.values()])

--- a/src/setup_status.py
+++ b/src/setup_status.py
@@ -148,14 +148,12 @@ async def send_friend_requests(nodes: Dict[str, StatusBackend],
 
     jobs = make_jobs(senders, receivers)
 
-    producer_task = asyncio.create_task(enqueue_jobs(job_q, jobs))
+    await enqueue_jobs(job_q, jobs)
     launcher_task = asyncio.create_task(
         launch_workers(nodes, job_q, done_q, intermediate_delay, max_in_flight=max_in_flight, func=_send_friend_request)
     )
     collector_task = asyncio.create_task(collect_results(done_q, send_friend_requests.__name__))
-    await asyncio.gather(producer_task, launcher_task)
-
-    results = await collector_task
+    _, results = await asyncio.gather(launcher_task, collector_task)
     logger.info(f"All {len(results)} friend requests processed (out of {len(jobs)}).")
 
     return results

--- a/src/setup_status.py
+++ b/src/setup_status.py
@@ -4,8 +4,10 @@ import logging
 import random
 import string
 import time
+from typing import Tuple, List, Dict, Optional
 
 # Project Imports
+from src.async_utils import make_jobs, enqueue_jobs, launch_workers, collect_results
 from src.enums import MessageContentType, SignalType
 from src.status_backend import StatusBackend
 
@@ -124,26 +126,46 @@ async def reject_community_requests(owner: StatusBackend, join_ids: list[str]):
 
     logger.info(f"All {len(join_ids)} nodes have been rejected successfully")
 
-async def send_friend_requests(nodes: dict[str, StatusBackend], senders: list[str], receivers: list[str]):
-    async def _send_friend_request(nodes: dict[str, StatusBackend], sender: str, receivers: list[str]):
-        # Send contact requests from sender -> receivers
-        responses = await asyncio.gather(*[nodes[sender].wakuext_service.send_contact_request(nodes[node].public_key, "asd") for node in receivers])
-        # Get responses and filter by contact requests
-        request_responses = await asyncio.gather(*[get_messages_by_content_type(response, MessageContentType.CONTACT_REQUEST.value) for response in responses])
-        # Create a dict {receiver: request}, using the first response (there is always only one friend request)
-        request_ids = {receiver: request_responses[i][0].get("id") for i, receiver in enumerate(receivers)}
 
-        return sender, request_ids
+async def send_friend_requests(nodes: Dict[str, StatusBackend],
+                               senders: List[str],
+                               receivers: List[str],
+                               intermediate_delay: float,
+                               max_in_flight: int = 0,
+                               ) -> List[Tuple[str, Dict[str, Tuple[int, str]]]]:
 
-    requests_made = await asyncio.gather(*[_send_friend_request(nodes, sender, receivers) for sender in senders])
-    # Returns a list of tuples like: [(sender name, {receiver: request_id, ...})]
-    logger.info(f"All {len(receivers)} friend requests sent.")
-    return requests_made
+    async def _send_friend_request(nodes: dict[str, StatusBackend], sender: str, receiver: str):
+        response = await nodes[sender].wakuext_service.send_contact_request(nodes[receiver].public_key, "Friend Request")
+        # Get responses and filter by contact requests to obtain request ids
+        request_response = await get_messages_by_content_type(response, MessageContentType.CONTACT_REQUEST.value)
+        # Create a dict {receiver: (response_timestamp, request)}, using the first response (there is always only one friend request)
+        request_id = {receiver: (int(request_response[0].get("timestamp")), request_response[0].get("id"))}
+
+        return sender, request_id
+
+    job_q: asyncio.Queue[Optional[Tuple[str, str]]] = asyncio.Queue()
+    done_q: asyncio.Queue[asyncio.Task] = asyncio.Queue()
+
+    jobs = make_jobs(senders, receivers)
+
+    producer_task = asyncio.create_task(enqueue_jobs(job_q, jobs))
+    launcher_task = asyncio.create_task(
+        launch_workers(nodes, job_q, done_q, intermediate_delay, max_in_flight=max_in_flight, func=_send_friend_request)
+    )
+    collector_task = asyncio.create_task(collect_results(done_q, send_friend_requests.__name__))
+    await asyncio.gather(producer_task, launcher_task)
+
+    results = await collector_task
+    logger.info(f"All {len(results)} friend requests processed (out of {len(jobs)}).")
+
+    return results
 
 
-async def accept_friend_requests(nodes: dict[str, StatusBackend], requests: list[(str, dict[str, str])]):
-    # Flatten all tasks into a single list and execute them concurrently
-    async def _accept_friend_request(nodes: dict[str, StatusBackend], sender: str, receiver: str, request_id: str):
+async def accept_friend_requests(nodes: dict[str, StatusBackend],
+                                 requests: List[Tuple[str, dict[str, Tuple[int, str]]]]) -> List[float]:
+    # Flatten all tasks into a single list and execute them "concurrently"
+    async def _accept_friend_request(nodes: dict[str, StatusBackend], sender: str, receiver: str,
+                                     timestamp_request_id: Tuple[int, str]):
         max_retries = 40
         retry_interval = 0.5
 

--- a/src/setup_status.py
+++ b/src/setup_status.py
@@ -128,7 +128,7 @@ async def reject_community_requests(owner: StatusBackend, join_ids: list[str]):
     logger.info(f"All {len(join_ids)} nodes have been rejected successfully")
 
 
-async def send_friend_requests(nodes: dict[str, "StatusBackend"], senders: list[str], receivers: list[str],
+async def send_friend_requests(nodes: dict[str, StatusBackend], senders: list[str], receivers: list[str],
     intermediate_delay: float, max_in_flight: int = 0) -> list[RequestResult]:
 
     async def _send_friend_request(nodes: dict[str, StatusBackend], sender: str, receiver: str):

--- a/src/signal_client.py
+++ b/src/signal_client.py
@@ -159,7 +159,6 @@ class AsyncSignalClient:
 
         # TODO MAKE THIS TO BE TRIGGERED AUTOMATICALLY WHEN MESSAGE APPEARS
         while True:
-            # for signal in queue.recent():
             for message in queue.messages:
                 if event_string in message[1]:
                     # Remove the found signal from the buffer

--- a/src/signal_client.py
+++ b/src/signal_client.py
@@ -148,8 +148,8 @@ class AsyncSignalClient:
     async def wait_for_logout(self) -> dict:
         return await self.wait_for_signal(SignalType.NODE_LOGOUT.value)
 
-
-    async def find_signal_containing_string(self, signal_type: str, event_string: str, timeout: int = 20) \
+    # TODO should be applied to other places
+    async def find_signal_containing_string(self, signal_type: str, event_string: str, timeout: int = 10) \
             -> Optional[dict]:
         if signal_type not in self.signal_queues:
             raise ValueError(f"Signal type {signal_type} is not in the list of awaited signals")
@@ -157,13 +157,15 @@ class AsyncSignalClient:
         queue = self.signal_queues[signal_type]
         end_time = asyncio.get_event_loop().time() + timeout
 
+        # TODO MAKE THIS TO BE TRIGGERED AUTOMATICALLY WHEN MESSAGE APPEARS
         while True:
-            for signal in queue.recent():
-                if event_string in json.dumps(signal):
+            # for signal in queue.recent():
+            for message in queue.messages:
+                if event_string in message[1]:
                     # Remove the found signal from the buffer
-                    queue.buffer.remove(signal)
-                    logger.info(f"Found {signal_type} containing '{event_string}' in buffer")
-                    return signal
+                    # queue.buffer.remove(signal)
+                    logger.info(f"Found {signal_type} containing '{event_string}' in messages")
+                    return message
 
             if asyncio.get_event_loop().time() > end_time:
                 raise TimeoutError(f"{signal_type} containing '{event_string}' not found in {timeout} seconds")


### PR DESCRIPTION
This PR includes some fixes to deployment and most importantly a different approach to interact with status node.

I wanted to be able to interact with the Status without overwhelming it. As we were doing before, we were spawning all tasks at the same time. This was a problem, because if Alice wanted to send 100 friend requests, we were hitting the Status node to send 100 friend requests at a time.
Adding an intermediate delay or batching this could be an option, but the issue would be that we would need to wait for N requests * intermediate delay before starting processing the output.

With this approach of 2 Asynq queues (util functions still need to be a bit more general), we are able to send those tasks with intermediate delays, and also await for the results at the same time. Thanks to this, I was able to increase the number of friend request from 40 to 250 with low intermediate delay (0.2 seconds).

The good part of this approach is that it can also be used in other scenarios.
And the same scheme could be for sending requests and accepting requests.

In a similar way, just for sending friend requests we were doing:
1. Send all the requests the node needs to do
2. Await for the responses

Now that we do both at the same time, we can also modify:
1. Send friend requests and await for responses
2. Accept friend requests on receivers and await for responses

To be done at the same time. Also, this will facilitate when calculating delays for those operations (ie: send friend request and be accepted, under heavy load).